### PR TITLE
Keep persisted referrerString available in JavaScript even after app is closed

### DIFF
--- a/android/src/main/java/com/jdc/reactlibrary/RNReferrerModule.java
+++ b/android/src/main/java/com/jdc/reactlibrary/RNReferrerModule.java
@@ -2,13 +2,11 @@
 package com.jdc.reactlibrary;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.Promise;
-import com.facebook.react.bridge.Callback;
 
 public class RNReferrerModule extends ReactContextBaseJavaModule {
 
@@ -28,6 +26,6 @@ public class RNReferrerModule extends ReactContextBaseJavaModule {
   public void getReferrer(Promise promise) {
     Context context = getReactApplicationContext();
 
-    promise.resolve(ReferrerReceiver.getReferrer());
+    promise.resolve(ReferrerReceiver.getReferrerFromSharedPreferences(context));
   }
 }

--- a/android/src/main/java/com/jdc/reactlibrary/ReferrerReceiver.java
+++ b/android/src/main/java/com/jdc/reactlibrary/ReferrerReceiver.java
@@ -4,21 +4,27 @@ package com.jdc.reactlibrary;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 
 public class ReferrerReceiver extends BroadcastReceiver {
-  private static String referrer = "";
+  public static final String REFERRER_PREFS_NAME = "referrerPreferences";
 
-  public static String getReferrer() {
-    return referrer;
+  public static String getReferrerFromSharedPreferences(Context context) {
+    SharedPreferences prefs = context.getSharedPreferences(REFERRER_PREFS_NAME, context.MODE_PRIVATE);
+    String storedReferrerString = prefs.getString("referrer", null);
+    return storedReferrerString;
   }
 
-  private static void setReferrer(String value) {
-    referrer = value;
+  private static void storeReferrerInSharedPreferences(String value, Context context) {
+    SharedPreferences.Editor editor = context.getSharedPreferences(REFERRER_PREFS_NAME, context.MODE_PRIVATE).edit();
+    editor.putString("referrer", value);
+    editor.apply();
   }
 
   @Override
   public void onReceive(Context context, Intent intent) {
     String referrerString = intent.getStringExtra("referrer");
-    setReferrer(referrerString);
+
+    storeReferrerInSharedPreferences(referrerString, context);
   }
 }


### PR DESCRIPTION
## Motivation
Ensure that the referrerString is still available in React Native / JavaScript even if the app is closed after the referrer Intent is broadcasted.

## Current behavior
The referrerString is only stored as a private variable in `ReferrerReceiver` and deallocated when closing the app.

## Expected behavior
The referrerString is stored in local storage with `SharedPreferences` and persisted even after the app is closed.